### PR TITLE
Add more unit tests, catch bug with pagination thanks to unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-merge-conflict
+      - id: no-commit-to-branch
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.10

--- a/src/xivapy/client.py
+++ b/src/xivapy/client.py
@@ -330,10 +330,10 @@ class Client:
                         row_id=result['row_id'],
                         data=model_instance,
                     )
-                # Are there more pages?
-                cursor = data.get('next')
-                if not cursor:
-                    break
+            # Are there more pages?
+            cursor = data.get('next')
+            if not cursor:
+                break
 
     async def asset(
         self, path: str, format: Format = 'png', version: Optional[str] = None

--- a/tests/fixtures/api_responses.py
+++ b/tests/fixtures/api_responses.py
@@ -1,3 +1,5 @@
+"""API responses to test against."""
+
 VERSIONS_RESPONSE = {
     'versions': [
         {'names': ['7.3x1']},
@@ -13,13 +15,36 @@ SHEETS_RESPONSE = {
     ]
 }
 
-SEARCH_RESPONSE = {
+BASIC_SEARCH_RESPONSE = {
     'results': [
         {
             'score': 1.0,
             'sheet': 'TestSheet',
             'row_id': 1,
             'fields': {'Name': 'Test Item', 'Level': 50},
+        }
+    ],
+    'next': None,
+}
+
+SEARCH_RESPONSE_PAGE_1 = {
+    'results': [
+        {
+            'score': 1.0,
+            'sheet': 'TestSheet',
+            'row_id': 23,
+            'fields': {'Name': 'Test Item', 'Level': 89},
+        }
+    ],
+    'next': '28433b5b-7860-4395-88df-17c75c173a7c',
+}
+SEARCH_RESPONSE_PAGE_2 = {
+    'results': [
+        {
+            'score': 0.899,
+            'sheet': 'TestSheet',
+            'row_id': 212,
+            'fields': {'Name': 'Another Test Item', 'Level': 50},
         }
     ],
     'next': None,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,23 @@
 """Tests related to xivapy.Client."""
 
+from typing import Annotated
 from pytest_httpx import HTTPXMock
+import httpx
 import pytest
 
-from xivapy.client import Client
+from xivapy.client import Client, SearchResult
+from xivapy.model import Model
 from xivapy.exceptions import XIVAPIHTTPError, XIVAPINotFoundError
+
+from tests.fixtures.api_responses import (
+    BASIC_SEARCH_RESPONSE,
+    SEARCH_RESPONSE_PAGE_1,
+    SEARCH_RESPONSE_PAGE_2,
+    VERSIONS_RESPONSE,
+    SHEETS_RESPONSE,
+    SHEET_ROW_RESPONSE,
+)
+from xivapy.model import FieldMapping
 
 
 async def test_client_close():
@@ -33,13 +46,13 @@ async def test_versions_success(httpx_mock: HTTPXMock):
     """Test version endpoint with good response."""
     httpx_mock.add_response(
         url='https://v2.xivapi.com/api/version',
-        json={'versions': [{'names': ['latest']}, {'names': ['7.3x1']}]},
+        json=VERSIONS_RESPONSE,
     )
 
     async with Client() as client:
         versions = await client.versions()
-        assert 'latest' in versions
         assert '7.3x1' in versions
+        assert 'latest' in versions
 
 
 async def test_versions_http_error(httpx_mock: HTTPXMock):
@@ -59,13 +72,14 @@ async def test_sheets_success(httpx_mock: HTTPXMock):
     """Test sheets endpoint with good response."""
     httpx_mock.add_response(
         url='https://v2.xivapi.com/api/sheet?version=latest',
-        json={'sheets': [{'name': 'Item'}, {'name': 'ContentUICondition'}]},
+        json=SHEETS_RESPONSE,
     )
 
     async with Client() as client:
         sheets = await client.sheets()
         assert 'Item' in sheets
-        assert 'ContentUICondition' in sheets
+        assert 'ContentFinderCondition' in sheets
+        assert 'Quest' in sheets
 
 
 async def test_sheets_http_error(httpx_mock: HTTPXMock):
@@ -144,3 +158,93 @@ async def test_asset_none_found(httpx_mock: HTTPXMock):
     async with Client() as client:
         asset = await client.asset(path='ui/icon/selene.tex', format='png')
         assert asset == None
+
+
+async def test_search_success(httpx_mock: HTTPXMock):
+    """Test searching something where it's a single result."""
+
+    class TestSheet(Model):
+        id: Annotated[int, FieldMapping('row_id')]
+        name: Annotated[str, FieldMapping('Name')]
+        level: Annotated[int, FieldMapping('Level')]
+
+    expected_fields = TestSheet.get_fields_str()
+    httpx_mock.add_response(
+        url=httpx.URL(
+            'https://v2.xivapi.com/api/search',
+            params={
+                'sheets': 'TestSheet',
+                'query': '+Name="Test Item" +Level=50',
+                'fields': expected_fields,
+                'version': 'latest',
+            },
+        ),
+        json=BASIC_SEARCH_RESPONSE,
+    )
+
+    client = Client()
+
+    res_iter = aiter(client.search(TestSheet, query='+Name="Test Item" +Level=50'))
+
+    item = await anext(res_iter)
+    assert isinstance(item, SearchResult)
+    assert item.score == pytest.approx(1.0)
+    assert item.sheet == 'TestSheet'
+    assert isinstance(item.data, TestSheet)
+    assert item.data.id == 1
+    assert item.data.name == 'Test Item'
+    assert item.data.level == 50
+
+
+# @pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+async def test_paginated_search_success(httpx_mock: HTTPXMock):
+    """Test getting multiple pages from the search endpoint with a cursor."""
+
+    class TestSheet(Model):
+        id: Annotated[int, FieldMapping('row_id')]
+        name: Annotated[str, FieldMapping('Name')]
+        level: Annotated[int, FieldMapping('Level')]
+
+    expected_fields = TestSheet.get_fields_str()
+
+    httpx_mock.add_response(
+        url=httpx.URL(
+            'https://v2.xivapi.com/api/search',
+            params={
+                'sheets': 'TestSheet',
+                'query': 'Name~"Test Item" Level=50',
+                'fields': expected_fields,
+                'version': 'latest',
+            },
+        ),
+        json=SEARCH_RESPONSE_PAGE_1,
+    )
+    httpx_mock.add_response(
+        url=httpx.URL(
+            'https://v2.xivapi.com/api/search',
+            params={
+                'sheets': 'TestSheet',
+                'cursor': '28433b5b-7860-4395-88df-17c75c173a7c',
+                'fields': expected_fields,
+                'version': 'latest',
+            },
+        ),
+        json=SEARCH_RESPONSE_PAGE_2,
+    )
+
+    client = Client()
+
+    req_iter = aiter(client.search(TestSheet, query='Name~"Test Item" Level=50'))
+
+    item = await anext(req_iter)
+    assert isinstance(item, SearchResult)
+    assert item.data.name == 'Test Item'
+    assert item.data.level == 89
+
+    item = await anext(req_iter)
+    assert isinstance(item, SearchResult)
+    assert item.data.name == 'Another Test Item'
+    assert item.data.level == 50
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(req_iter)


### PR DESCRIPTION
Add more unit tests for the client; in doing so I discovered a bug with the logic in `Client.search` in that we're trying to check for the next token inside a for loop, which will attempt to loop some more instead of, y'know, raising `StopAsyncIteration`.

This PR technically sneaks in something in a different area, but it's useful to keep people from accidentally committing to main.