### PR TITLE
Model querying

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,13 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
+        exclude: '^src/xivapy/model\.pyi$'
         additional_dependencies: [httpx, pydantic, aiostream]
         args:
           [
             --ignore-missing-imports,
-            --warn-unused-ignores,
             --warn-redundant-casts,
+            --explicit-package-bases,
+            --namespace-packages,
+            --no-site-packages,
           ]

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ pip install xivapy
 The easiest way to use the client is to define a model and try looking through a sheet with a search.
 
 ```python
-import typing
-from pydantic import Field
 import xivapy
 
 class ContentFinderCondition(xivapy.Model):
     # Custom map a python field to an xivapi field name
-    id: int = Field(alias='row_id')
+    id: xivapy.QueryField[int] = xivapy.QueryField(FieldMapping('row_id'))
     # compress language fields into a dictionary for easy viewing
     # for this, however, you'll need to set up a default dict for it to use
     # The output of this is:
@@ -37,9 +35,9 @@ class ContentFinderCondition(xivapy.Model):
     #   'ja': "護る者、壊す者"
     # }
     # Optional languages will be omitted
-    name: Annotated[xivapy.LangDict, xivapy.FieldMapping('Name', languages=['en', 'de', 'fr', 'ja'])] = Field(default_factory=lambda: xivapy.LangDict.copy())
+    name: xivapy.QueryField[xivapy.LangDict] = xivapy.QueryField(FieldMapping('Name', languages=['en', 'de', 'fr', 'ja']))
     # get a deeply nested (and optional) field lifted up into a top-level field
-    bgm_file: Annotated[str | None, xivapy.FieldMapping('Content.BGM.File')] = None
+    bgm_file: xivapy.QueryField[str | None] = xivapy.QueryField(xivapy.FieldMapping('Content.BGM.File'))
     # by default, the sheet to be searched will be the name of the model
     # if you wish to override this, set the following:
     #__sheetname__ = 'SomeOtherSheetName'
@@ -48,7 +46,7 @@ async with xivapy.Client() as client:
     # Search ContentFinderCondition for all content that mentor roulette applies to
     async for content in client.search(ContentFinderCondition, query=xivapy.QueryBuilder().where(MentorRoulette=1)):
         # Data is typed as SearchResult[ContentFinderCondition], accessable by the `.data` field
-        print(f'{content.data.name} ({content.data.id}) - {content.data.bgm_file}')
+        print(f'{content.data.name.get('en', 'No English Name')} ({content.data.id}) - {content.data.bgm_file}')
 
     # The same thing, but for a single id:
     result = await client.sheet(ContentFinderCondition, row=998)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xivapy"
-version = "0.4.0"
+version = "0.5.0"
 description = "Async Python client for XIVAPI for Final Fantasy XIV"
 readme = "README.md"
 requires-python = ">=3.13.2"
@@ -26,6 +26,14 @@ Documentation = "https://github.com/macrocosmos-app/xivapy#readme"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.mypy]
+ignore_missing_imports = true
+warn_redundant_casts = true
+explicit_package_bases = true
+namespace_packages = true
+no_site_packages = true
+exclude = ["build/", "dist/", ".venv/"]
 
 [tool.ruff.lint]
 select = ["D"]

--- a/src/xivapy/__init__.py
+++ b/src/xivapy/__init__.py
@@ -2,7 +2,7 @@
 
 from xivapy.client import Client, SearchResult
 from xivapy.query import Query, QueryBuilder, Group
-from xivapy.model import FieldMapping, Model
+from xivapy.model import QueryField, FieldMapping, Model
 
 # TODO: maybe scope this so people can xivapi.types.Format?
 # For now the api surface is small, so we don't have conflicts anyway
@@ -15,6 +15,7 @@ __all__ = [
     'Query',
     'QueryBuilder',
     'Group',
+    'QueryField',
     'FieldMapping',
     'Model',
     'LangDict',

--- a/src/xivapy/client.py
+++ b/src/xivapy/client.py
@@ -491,7 +491,7 @@ class Client:
         if hasattr(rows, '__aiter__'):
             # mypy can't resolve aiostream types correctly in some cases - see upstream issue:
             # https://github.com/vxgmichel/aiostream/issues/105
-            async with chunks(rows, self.batch_size).stream() as streamer:  # type: ignore[arg-type,var-annotated]
+            async with chunks(rows, self.batch_size).stream() as streamer:  # pyright: ignore[reportArgumentType]
                 async for batch in streamer:
                     batch_seq = cast(Sequence[int], batch)
                     async for item in self._process_batch(
@@ -499,7 +499,7 @@ class Client:
                     ):
                         yield item
         else:
-            for batch in batched(rows, self.batch_size):  # type: ignore[assignment]
+            for batch in batched(rows, self.batch_size):  # pyright: ignore[reportArgumentType]
                 async for item in self._process_batch(model_class, batch, **params):
                     yield item
 

--- a/src/xivapy/model.pyi
+++ b/src/xivapy/model.pyi
@@ -1,0 +1,37 @@
+from typing import Optional, Any, overload
+from dataclasses import dataclass
+from pydantic import BaseModel
+from xivapy.query import QueryDescriptor, Query
+
+@dataclass
+class FieldMapping:
+    base_field: str
+    languages: Optional[list[str]] = None
+    raw: bool = False
+    html: bool = False
+    custom_spec: Optional[str] = None
+    def to_field_specs(self) -> list[str]: ...
+
+# For type checkers, QueryField[T] looks like QueryDescriptor
+class QueryField[T](QueryDescriptor):
+    def __init__(self, mapping: Optional[FieldMapping] = None) -> None: ...
+    def __set_name__(self, owner: Any, name: str) -> None: ...
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> Any: ...
+
+    # Descriptor stuff
+    @overload
+    def __get__(self, instance: None, owner: Any) -> QueryDescriptor: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> T: ...
+
+class Model(BaseModel):
+    __sheetname__: Optional[str]
+    @classmethod
+    def get_sheet_name(cls) -> str: ...
+    @classmethod
+    def get_fields_str(cls) -> str: ...
+    @classmethod
+    def get_xivapi_fields(cls) -> set[str]: ...
+    @classmethod
+    def process_xivapi_response(cls, data: dict[str, Any]) -> dict[str, Any]: ...

--- a/src/xivapy/types.py
+++ b/src/xivapy/types.py
@@ -2,9 +2,10 @@
 
 from typing import Literal, TypedDict
 
-__all__ = ['Format', 'LangDict']
+__all__ = ['Format', 'LangDict', 'QueryOperators']
 
 Format = Literal['png', 'jpg', 'webp']
+QueryOperators = Literal['=', '~', '<', '<=', '>', '>=']
 
 
 class LangDict(TypedDict, total=False):

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "xivapy"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },


### PR DESCRIPTION
This lands a feature that allows you to use `xivapy.Model` as a query source. In short:

Old:
```python
query = QueryBuilder().where(Name='Foo').gt(Level>=10)
```
New:
```python
class Item(Model):
    name: QueryField[str] = QueryField(FieldMapping('Name')
    level: QueryField[int] = QueryField(FieldMapping('Level')

query = QueryBuilder().where(Item.name == 'Foo', Item.level >= 10)
```

You can omit the instantiation if you're just going to keep them as `Name`, `Level`, etc.

There's a lot of Deep Magic under the hood:

* Before runtime, fields are definitely a QueryField; at runtime, they become QueryDescriptors (which are themselves before being instantiated, but offer their instance value after becoming instantiated)
* There's a metaclass for pydantic that hooks news and grabs these query fields at `__new__` time to swap them over
* I had to add a .pyi stub to help type checkers understand what's going on with if a value is QueryField[T]/QueryDescriptor/T, but it worked out in the end

All current functionality is preserved (`foo: Annotated[str, FieldMapping(...)]` or `Foo: int`), but you don't get query support without that QueryField annotation/instantiation.